### PR TITLE
Add backend architecture with config flow and layered storage

### DIFF
--- a/custom_components/irsinn/__init__.py
+++ b/custom_components/irsinn/__init__.py
@@ -37,6 +37,9 @@ COMPONENT_ABS_DIR = os.path.dirname(
 
 CONF_CHECK_UPDATES = 'check_updates'
 CONF_UPDATE_BRANCH = 'update_branch'
+CONF_ENTITY_TYPE = 'entity_type'
+
+PLATFORMS = ["remote", "climate", "fan", "light", "media_player"]
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -140,12 +143,14 @@ async def async_setup_entry(hass: HomeAssistant, entry) -> bool:
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN].setdefault("storage", StorageManager(hass))
     hass.data[DOMAIN].setdefault("entities", {})
-    await hass.config_entries.async_forward_entry_setups(entry, ["remote"])
+    platform = entry.data.get(CONF_ENTITY_TYPE, "remote")
+    await hass.config_entries.async_forward_entry_setups(entry, [platform])
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry) -> bool:
-    return await hass.config_entries.async_unload_platforms(entry, ["remote"])
+    platform = entry.data.get(CONF_ENTITY_TYPE, "remote")
+    return await hass.config_entries.async_unload_platforms(entry, [platform])
 
 
 async def async_get_device_config(domain: str, device_code: int) -> dict[str, Any]:

--- a/custom_components/irsinn/backends/__init__.py
+++ b/custom_components/irsinn/backends/__init__.py
@@ -1,0 +1,47 @@
+"""Backend interface and factory for IRsinn."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Dict, Type
+
+from homeassistant.core import HomeAssistant
+
+SUPPORTED_BACKENDS: Dict[str, Type["IRBackend"]] = {}
+
+
+class IRBackend(ABC):
+    """Abstract backend used by IRsinn to send and learn IR commands."""
+
+    def __init__(self, hass: HomeAssistant, controller_data: str, delay: float) -> None:
+        self.hass = hass
+        self._controller_data = controller_data
+        self._delay = delay
+
+    @abstractmethod
+    async def async_send(self, command: str) -> None:
+        """Send a command to the backend."""
+
+    async def async_learn(self) -> str | None:  # pragma: no cover - backend optional
+        """Learn a command from the backend."""
+        return None
+
+
+def register_backend(name: str, backend: Type[IRBackend]) -> None:
+    """Register a backend implementation."""
+    SUPPORTED_BACKENDS[name] = backend
+
+
+def get_backend(
+    hass: HomeAssistant, name: str, controller_data: str, delay: float
+) -> IRBackend:
+    """Return an instance of a registered backend."""
+    backend_cls = SUPPORTED_BACKENDS.get(name)
+    if backend_cls is None:
+        raise ValueError(f"Backend {name} not supported")
+    return backend_cls(hass, controller_data, delay)
+
+
+# Import built-in backends so they register on import
+from . import zha_backend  # noqa: F401
+from . import zigbee2mqtt_backend  # noqa: F401

--- a/custom_components/irsinn/backends/__init__.py
+++ b/custom_components/irsinn/backends/__init__.py
@@ -26,6 +26,16 @@ class IRBackend(ABC):
         """Learn a command from the backend."""
         return None
 
+    @classmethod
+    async def async_controller_options(cls, hass: HomeAssistant) -> dict[str, str]:
+        """Return available controller options for this backend.
+
+        The returned mapping maps a controller identifier to a human readable name
+        that will be presented in the config flow. Backends can override this
+        method to provide discovery of IR blaster devices.
+        """
+        return {}
+
 
 def register_backend(name: str, backend: Type[IRBackend]) -> None:
     """Register a backend implementation."""

--- a/custom_components/irsinn/backends/zha_backend.py
+++ b/custom_components/irsinn/backends/zha_backend.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from homeassistant.helpers.device_registry import async_get as async_get_dr
+
 from . import IRBackend, register_backend
 
 ZHA_CLUSTER_ID = 0xE004  # cluster used for IR commands
@@ -24,6 +26,17 @@ class ZhaBackend(IRBackend):
         await self.hass.services.async_call(
             "zha", "issue_zigbee_cluster_command", service_data
         )
+
+    @classmethod
+    async def async_controller_options(cls, hass):
+        """Return available ZHA devices for selection."""
+        registry = async_get_dr(hass)
+        controllers: dict[str, str] = {}
+        for device in registry.devices.values():
+            for domain, ident in device.identifiers:
+                if domain == "zha":
+                    controllers[ident] = device.name or ident
+        return controllers
 
 
 register_backend("zha", ZhaBackend)

--- a/custom_components/irsinn/backends/zha_backend.py
+++ b/custom_components/irsinn/backends/zha_backend.py
@@ -1,0 +1,29 @@
+"""ZHA backend implementation for IRsinn."""
+
+from __future__ import annotations
+
+from . import IRBackend, register_backend
+
+ZHA_CLUSTER_ID = 0xE004  # cluster used for IR commands
+ZHA_COMMAND_ID = 2
+
+
+class ZhaBackend(IRBackend):
+    """Backend that sends commands via ZHA."""
+
+    async def async_send(self, command: str) -> None:
+        service_data = {
+            "cluster_type": "in",
+            "endpoint_id": 1,
+            "command": ZHA_COMMAND_ID,
+            "ieee": self._controller_data,
+            "command_type": "server",
+            "params": {"code": command},
+            "cluster_id": ZHA_CLUSTER_ID,
+        }
+        await self.hass.services.async_call(
+            "zha", "issue_zigbee_cluster_command", service_data
+        )
+
+
+register_backend("zha", ZhaBackend)

--- a/custom_components/irsinn/backends/zigbee2mqtt_backend.py
+++ b/custom_components/irsinn/backends/zigbee2mqtt_backend.py
@@ -14,5 +14,10 @@ class Zigbee2MQTTBackend(IRBackend):
             "mqtt", "publish", {"topic": topic, "payload": command}
         )
 
+    @classmethod
+    async def async_controller_options(cls, hass):  # pragma: no cover - stub
+        """Return discovered MQTT topics, if any."""
+        return {}
+
 
 register_backend("zigbee2mqtt", Zigbee2MQTTBackend)

--- a/custom_components/irsinn/backends/zigbee2mqtt_backend.py
+++ b/custom_components/irsinn/backends/zigbee2mqtt_backend.py
@@ -1,0 +1,18 @@
+"""Zigbee2MQTT backend stub."""
+
+from __future__ import annotations
+
+from . import IRBackend, register_backend
+
+
+class Zigbee2MQTTBackend(IRBackend):
+    """Backend placeholder for Zigbee2MQTT."""
+
+    async def async_send(self, command: str) -> None:
+        topic = f"{self._controller_data}/set"
+        await self.hass.services.async_call(
+            "mqtt", "publish", {"topic": topic, "payload": command}
+        )
+
+
+register_backend("zigbee2mqtt", Zigbee2MQTTBackend)

--- a/custom_components/irsinn/config_flow.py
+++ b/custom_components/irsinn/config_flow.py
@@ -7,6 +7,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.data_entry_flow import FlowResult
 
+from . import CONF_ENTITY_TYPE
 from .backends import SUPPORTED_BACKENDS
 from .remote import (
     CONF_BACKEND,
@@ -22,9 +23,52 @@ from .remote import (
 class IRsinnConfigFlow(config_entries.ConfigFlow, domain="irsinn"):
     """Handle a config flow for IRsinn."""
 
+    def __init__(self) -> None:
+        self._backend: str | None = None
+        self._entity_type: str | None = None
+
     async def async_step_user(self, user_input=None) -> FlowResult:
+        """Select entity type and backend."""
         if user_input is not None:
-            return self.async_create_entry(title=user_input[CONF_NAME], data=user_input)
+            self._entity_type = user_input[CONF_ENTITY_TYPE]
+            self._backend = user_input[CONF_BACKEND]
+            return await self.async_step_device()
+
+        entity_types = ["remote", "climate", "fan", "light", "media_player"]
+        data_schema = vol.Schema(
+            {
+                vol.Required(CONF_ENTITY_TYPE): vol.In(entity_types),
+                vol.Required(CONF_BACKEND): vol.In(sorted(SUPPORTED_BACKENDS)),
+            }
+        )
+        return self.async_show_form(step_id="user", data_schema=data_schema)
+
+    async def async_step_device(self, user_input=None) -> FlowResult:
+        """Collect device specific settings."""
+        assert self._backend is not None and self._entity_type is not None
+
+        if user_input is not None:
+            data = {
+                CONF_NAME: user_input[CONF_NAME],
+                CONF_UNIQUE_ID: user_input[CONF_UNIQUE_ID],
+                CONF_DEVICE_CODE: user_input[CONF_DEVICE_CODE],
+                CONF_DELAY: user_input.get(CONF_DELAY, DEFAULT_DELAY),
+                CONF_BACKEND: self._backend,
+                CONF_CONTROLLER_DATA: user_input[CONF_CONTROLLER_DATA],
+                CONF_ENTITY_TYPE: self._entity_type,
+            }
+            return self.async_create_entry(title=data[CONF_NAME], data=data)
+
+        backend_cls = SUPPORTED_BACKENDS[self._backend]
+        controllers = await backend_cls.async_controller_options(self.hass)
+        if controllers:
+            controller_field = vol.Required(
+                CONF_CONTROLLER_DATA, default=next(iter(controllers))
+            )
+            controller_validator = vol.In(controllers)
+        else:
+            controller_field = vol.Required(CONF_CONTROLLER_DATA)
+            controller_validator = str
 
         data_schema = vol.Schema(
             {
@@ -32,8 +76,7 @@ class IRsinnConfigFlow(config_entries.ConfigFlow, domain="irsinn"):
                 vol.Required(CONF_UNIQUE_ID): str,
                 vol.Required(CONF_DEVICE_CODE): int,
                 vol.Optional(CONF_DELAY, default=DEFAULT_DELAY): float,
-                vol.Required(CONF_BACKEND): vol.In(sorted(SUPPORTED_BACKENDS)),
-                vol.Required(CONF_CONTROLLER_DATA): str,
+                controller_field: controller_validator,
             }
         )
-        return self.async_show_form(step_id="user", data_schema=data_schema)
+        return self.async_show_form(step_id="device", data_schema=data_schema)

--- a/custom_components/irsinn/config_flow.py
+++ b/custom_components/irsinn/config_flow.py
@@ -1,0 +1,39 @@
+"""Config flow for IRsinn integration."""
+
+from __future__ import annotations
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.data_entry_flow import FlowResult
+
+from .backends import SUPPORTED_BACKENDS
+from .remote import (
+    CONF_BACKEND,
+    CONF_CONTROLLER_DATA,
+    CONF_DELAY,
+    CONF_DEVICE_CODE,
+    CONF_NAME,
+    CONF_UNIQUE_ID,
+    DEFAULT_DELAY,
+)
+
+
+class IRsinnConfigFlow(config_entries.ConfigFlow, domain="irsinn"):
+    """Handle a config flow for IRsinn."""
+
+    async def async_step_user(self, user_input=None) -> FlowResult:
+        if user_input is not None:
+            return self.async_create_entry(title=user_input[CONF_NAME], data=user_input)
+
+        data_schema = vol.Schema(
+            {
+                vol.Required(CONF_NAME): str,
+                vol.Required(CONF_UNIQUE_ID): str,
+                vol.Required(CONF_DEVICE_CODE): int,
+                vol.Optional(CONF_DELAY, default=DEFAULT_DELAY): float,
+                vol.Required(CONF_BACKEND): vol.In(sorted(SUPPORTED_BACKENDS)),
+                vol.Required(CONF_CONTROLLER_DATA): str,
+            }
+        )
+        return self.async_show_form(step_id="user", data_schema=data_schema)

--- a/custom_components/irsinn/irsinn-panel.js
+++ b/custom_components/irsinn/irsinn-panel.js
@@ -1,0 +1,12 @@
+class IRsinnPanel extends HTMLElement {
+  connectedCallback() {
+    this.innerHTML = `
+      <ha-card header="IRsinn Commands">
+        <table>
+          <tr><th>Key</th><th>Value (Base64)</th><th>Actions</th></tr>
+        </table>
+      </ha-card>
+    `;
+  }
+}
+customElements.define('irsinn-panel', IRsinnPanel);

--- a/custom_components/irsinn/manifest.json
+++ b/custom_components/irsinn/manifest.json
@@ -6,6 +6,7 @@
   "codeowners": ["@sKuhLight"],
   "requirements": ["aiofiles>=0.6.0"],
   "homeassistant": "2025.5.0",
+  "config_flow": true,
   "version": "1.19.0",
   "updater": {
     "version": "1.19.0",

--- a/custom_components/irsinn/remote.py
+++ b/custom_components/irsinn/remote.py
@@ -3,7 +3,11 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.components.remote import RemoteEntity, PLATFORM_SCHEMA, RemoteEntityFeature
+from homeassistant.components.remote import (
+    RemoteEntity,
+    PLATFORM_SCHEMA,
+    RemoteEntityFeature,
+)
 from homeassistant.const import CONF_NAME
 import homeassistant.helpers.config_validation as cv
 from homeassistant.core import HomeAssistant
@@ -11,8 +15,9 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType
 
-from . import async_get_device_config
-from .controller import get_controller
+from . import DOMAIN
+from .backends import get_backend, SUPPORTED_BACKENDS
+from .storage_manager import StorageManager
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -23,6 +28,7 @@ CONF_UNIQUE_ID = "unique_id"
 CONF_DEVICE_CODE = "device_code"
 CONF_CONTROLLER_DATA = "controller_data"
 CONF_DELAY = "delay"
+CONF_BACKEND = "backend"
 
 SUPPORT_FLAGS = (
     RemoteEntityFeature.LEARN_COMMAND | RemoteEntityFeature.DELETE_COMMAND
@@ -35,6 +41,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Required(CONF_DEVICE_CODE): cv.positive_int,
         vol.Required(CONF_CONTROLLER_DATA): cv.string,
         vol.Optional(CONF_DELAY, default=DEFAULT_DELAY): cv.positive_float,
+        vol.Required(CONF_BACKEND): vol.In(sorted(SUPPORTED_BACKENDS)),
     }
 )
 
@@ -48,39 +55,57 @@ async def async_setup_platform(
     """Set up the IR Remote platform."""
     device_code = config.get(CONF_DEVICE_CODE)
 
+    storage: StorageManager = hass.data.get(DOMAIN, {}).get("storage") or StorageManager(hass)
     try:
-        device_data = await async_get_device_config("remote", device_code)
+        device_data = await storage.async_load_device("remote", device_code)
     except Exception:
         _LOGGER.error("The device JSON file is invalid")
         return
+    backend = get_backend(
+        hass,
+        config[CONF_BACKEND],
+        config[CONF_CONTROLLER_DATA],
+        config[CONF_DELAY],
+    )
 
-    async_add_entities([IRsinnRemote(hass, config, device_data)])
+    async_add_entities([IRsinnRemote(hass, config, device_data, backend, storage)])
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry, async_add_entities: AddEntitiesCallback
+):
+    """Set up IRsinn remote from a config entry."""
+    storage: StorageManager = hass.data.get(DOMAIN, {}).get("storage") or StorageManager(hass)
+    device_code = entry.data[CONF_DEVICE_CODE]
+    device_data = await storage.async_load_device("remote", device_code)
+    backend = get_backend(
+        hass,
+        entry.data[CONF_BACKEND],
+        entry.data[CONF_CONTROLLER_DATA],
+        entry.data.get(CONF_DELAY, DEFAULT_DELAY),
+    )
+    async_add_entities([IRsinnRemote(hass, entry.data, device_data, backend, storage)])
 
 
 class IRsinnRemote(RemoteEntity, RestoreEntity):
-    def __init__(self, hass, config, device_data):
+    def __init__(self, hass, config, device_data, backend, storage: StorageManager):
         self.hass = hass
         self._unique_id = config.get(CONF_UNIQUE_ID)
         self._name = config.get(CONF_NAME)
         self._device_code = config.get(CONF_DEVICE_CODE)
         self._controller_data = config.get(CONF_CONTROLLER_DATA)
         self._delay = config.get(CONF_DELAY)
+        self._backend_name = config.get(CONF_BACKEND)
 
         self._manufacturer = device_data.get("manufacturer")
         self._supported_models = device_data.get("supportedModels")
-        self._supported_controller = device_data.get("supportedController")
         self._commands_encoding = device_data.get("commandsEncoding")
         self._device_class = device_data.get("device_class")
         self._commands = device_data.get("commands", {})
 
         self._is_on = False
-        self._controller = get_controller(
-            hass,
-            self._supported_controller,
-            self._commands_encoding,
-            self._controller_data,
-            self._delay,
-        )
+        self._backend = backend
+        self._storage = storage
 
     @property
     def name(self):
@@ -113,21 +138,29 @@ class IRsinnRemote(RemoteEntity, RestoreEntity):
             "device_code": self._device_code,
             "manufacturer": self._manufacturer,
             "supported_models": self._supported_models,
-            "supported_controller": self._supported_controller,
+            "backend": self._backend_name,
             "commands_encoding": self._commands_encoding,
         }
+
+    async def async_added_to_hass(self) -> None:
+        self.hass.data.setdefault(DOMAIN, {}).setdefault("entities", {})[
+            self.entity_id
+        ] = self
+
+    async def async_will_remove_from_hass(self) -> None:
+        self.hass.data.get(DOMAIN, {}).get("entities", {}).pop(self.entity_id, None)
 
     async def async_turn_on(self, **kwargs):
         command = self._commands.get("turn_on")
         if command is not None:
-            await self._controller.send(command)
+            await self._backend.async_send(command)
         self._is_on = True
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs):
         command = self._commands.get("turn_off")
         if command is not None:
-            await self._controller.send(command)
+            await self._backend.async_send(command)
         self._is_on = False
         self.async_write_ha_state()
 
@@ -138,7 +171,7 @@ class IRsinnRemote(RemoteEntity, RestoreEntity):
             commands = command
         for cmd in commands:
             if cmd in self._commands:
-                await self._controller.send(self._commands[cmd])
+                await self._backend.async_send(self._commands[cmd])
                 await asyncio.sleep(self._delay)
 
     async def async_learn_command(self, **kwargs):
@@ -146,8 +179,15 @@ class IRsinnRemote(RemoteEntity, RestoreEntity):
         command_data = kwargs.get("command_data", [])
         if command:
             self._commands[command] = command_data
+            await self._storage.async_save_command(
+                "remote", self._device_code, command, command_data
+            )
 
     async def async_delete_command(self, **kwargs):
         command = kwargs.get("command")
         if command in self._commands:
             self._commands.pop(command)
+            await self._storage.async_delete_command(
+                "remote", self._device_code, command
+            )
+

--- a/custom_components/irsinn/services.yaml
+++ b/custom_components/irsinn/services.yaml
@@ -2,3 +2,42 @@ check_updates:
   description: Check for IRsinn updates.
 update_component:
   description: Update IRsinn component.
+learn_command:
+  description: Learn an IR command and store it.
+  fields:
+    entity_id:
+      description: Target IRsinn remote entity.
+      example: remote.living_room
+    key:
+      description: Command name to store.
+      example: volume_up
+save_command:
+  description: Save an IR command.
+  fields:
+    entity_id:
+      description: Target IRsinn remote entity.
+      example: remote.living_room
+    key:
+      description: Command name.
+      example: power
+    code:
+      description: Base64 encoded IR command.
+      example: "aGVsbG8="
+delete_command:
+  description: Delete an IR command.
+  fields:
+    entity_id:
+      description: Target IRsinn remote entity.
+      example: remote.living_room
+    key:
+      description: Command name to delete.
+      example: power
+test_command:
+  description: Send a raw IR command without saving.
+  fields:
+    entity_id:
+      description: Target IRsinn remote entity.
+      example: remote.living_room
+    code:
+      description: Base64 encoded IR command to send.
+      example: "aGVsbG8="

--- a/custom_components/irsinn/storage_manager.py
+++ b/custom_components/irsinn/storage_manager.py
@@ -1,0 +1,52 @@
+"""Handle layered configuration for IRsinn commands."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.storage import Store
+
+
+STORAGE_KEY = "irsinn_overrides"
+
+
+class StorageManager:
+    """Merge default codes with user overrides."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        self.hass = hass
+        self._store: Store = Store(hass, 1, STORAGE_KEY)
+
+    async def async_load_device(self, domain: str, device_code: int) -> Dict[str, Any]:
+        """Load device configuration with overrides applied."""
+        from . import async_get_device_config  # avoid circular import
+
+        defaults = await async_get_device_config(domain, device_code)
+        overrides = await self._store.async_load() or {}
+        domain_data = overrides.get(domain, {})
+        device_override = domain_data.get(str(device_code), {})
+        commands = {**defaults.get("commands", {}), **device_override.get("commands", {})}
+        result = defaults.copy()
+        result["commands"] = commands
+        return result
+
+    async def async_save_command(
+        self, domain: str, device_code: int, key: str, value: str
+    ) -> None:
+        data = await self._store.async_load() or {}
+        domain_data = data.setdefault(domain, {})
+        device_data = domain_data.setdefault(str(device_code), {"commands": {}})
+        device_data["commands"][key] = value
+        await self._store.async_save(data)
+
+    async def async_delete_command(
+        self, domain: str, device_code: int, key: str
+    ) -> None:
+        data = await self._store.async_load() or {}
+        try:
+            commands = data[domain][str(device_code)]["commands"]
+        except KeyError:
+            return
+        commands.pop(key, None)
+        await self._store.async_save(data)


### PR DESCRIPTION
## Summary
- introduce pluggable IR backend interface with ZHA and Zigbee2MQTT implementations
- add StorageManager for layered command overrides
- support config flow with backend selection and new IR command services

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689209ca57b88326b256c0848e374202