### PR TITLE
Implement ZHA IR learning with debug logging

### DIFF
--- a/custom_components/irsinn/__init__.py
+++ b/custom_components/irsinn/__init__.py
@@ -13,10 +13,16 @@ import struct
 from typing import Any
 
 import voluptuous as vol
-from homeassistant.const import __version__ as current_ha_version
-from homeassistant.core import HomeAssistant
-import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.typing import ConfigType
+
+try:  # pragma: no cover - falls back when HA is not installed
+    from homeassistant.const import __version__ as current_ha_version
+    from homeassistant.core import HomeAssistant
+    import homeassistant.helpers.config_validation as cv
+    from homeassistant.helpers.typing import ConfigType
+except Exception:  # pragma: no cover - used only for tests
+    current_ha_version = "0.0.0"
+    HomeAssistant = Any  # type: ignore[misc, assignment]
+    cv = ConfigType = Any  # type: ignore[misc]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/irsinn/controller.py
+++ b/custom_components/irsinn/controller.py
@@ -13,8 +13,12 @@ from typing import Any, Iterable, List
 
 import requests
 
-from homeassistant.core import HomeAssistant
-from homeassistant.const import ATTR_ENTITY_ID
+try:  # pragma: no cover - allows tests without Home Assistant
+    from homeassistant.core import HomeAssistant
+    from homeassistant.const import ATTR_ENTITY_ID
+except Exception:  # pragma: no cover - Home Assistant not installed
+    HomeAssistant = Any  # type: ignore[misc, assignment]
+    ATTR_ENTITY_ID = "entity_id"
 
 from . import Helper
 

--- a/custom_components/irsinn/controller.py
+++ b/custom_components/irsinn/controller.py
@@ -262,10 +262,12 @@ class ZHAController(AbstractController):
                     "command": 0,
                     "ieee": self._controller_data,
                     "command_type": "server",
-                    "params": {"data": {"study": 1}},
+                    # the quirk expects a JSON string payload
+                    "params": {"data": json.dumps({"study": 1})},
                     "cluster_id": 57348,
                 }
                 try:
+                    _LOGGER.debug("Exiting learn mode")
                     await self.hass.services.async_call(
                         "zha", "issue_zigbee_cluster_command", exit_data
                     )
@@ -276,6 +278,7 @@ class ZHAController(AbstractController):
         _LOGGER.debug("Timed out waiting for learned IR code")
         # make a best effort to exit learn mode
         try:
+            _LOGGER.debug("Exiting learn mode after timeout")
             await self.hass.services.async_call(
                 "zha",
                 "issue_zigbee_cluster_command",
@@ -285,7 +288,7 @@ class ZHAController(AbstractController):
                     "command": 0,
                     "ieee": self._controller_data,
                     "command_type": "server",
-                    "params": {"data": {"study": 1}},
+                    "params": {"data": json.dumps({"study": 1})},
                     "cluster_id": 57348,
                 },
             )

--- a/custom_components/irsinn/remote.py
+++ b/custom_components/irsinn/remote.py
@@ -35,7 +35,7 @@ except Exception:  # pragma: no cover - Home Assistant not available
     cv = _CV()
     HomeAssistant = AddEntitiesCallback = ConfigType = Any
 
-from . import async_get_device_config
+from . import DOMAIN, async_get_device_config
 from .controller import get_controller
 
 _LOGGER = logging.getLogger(__name__)
@@ -105,6 +105,11 @@ class IRsinnRemote(RemoteEntity, RestoreEntity):
             self._controller_data,
             self._delay,
         )
+
+    async def async_added_to_hass(self) -> None:
+        """Register entity for domain services."""
+        await super().async_added_to_hass()
+        self.hass.data.setdefault(DOMAIN, {})[self.entity_id] = self
 
     @property
     def name(self):

--- a/custom_components/irsinn/remote.py
+++ b/custom_components/irsinn/remote.py
@@ -1,15 +1,39 @@
 import asyncio
 import logging
+from typing import Any
 
 import voluptuous as vol
 
-from homeassistant.components.remote import RemoteEntity, PLATFORM_SCHEMA, RemoteEntityFeature
-from homeassistant.const import CONF_NAME
-import homeassistant.helpers.config_validation as cv
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.restore_state import RestoreEntity
-from homeassistant.helpers.typing import ConfigType
+try:  # pragma: no cover - allows tests without Home Assistant
+    from homeassistant.components.remote import (
+        RemoteEntity,
+        PLATFORM_SCHEMA,
+        RemoteEntityFeature,
+    )
+    from homeassistant.const import CONF_NAME
+    import homeassistant.helpers.config_validation as cv
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+    from homeassistant.helpers.restore_state import RestoreEntity
+    from homeassistant.helpers.typing import ConfigType
+except Exception:  # pragma: no cover - Home Assistant not available
+    RemoteEntity = type("RemoteEntity", (object,), {})  # type: ignore
+    RestoreEntity = type("RestoreEntity", (object,), {})  # type: ignore
+
+    class RemoteEntityFeature:  # type: ignore
+        LEARN_COMMAND = 0
+        DELETE_COMMAND = 0
+
+    PLATFORM_SCHEMA = vol.Schema({})
+    CONF_NAME = "name"
+
+    class _CV:  # minimal stand-ins for Home Assistant validators
+        string = str
+        positive_int = int
+        positive_float = float
+
+    cv = _CV()
+    HomeAssistant = AddEntitiesCallback = ConfigType = Any
 
 from . import async_get_device_config
 from .controller import get_controller
@@ -142,10 +166,26 @@ class IRsinnRemote(RemoteEntity, RestoreEntity):
                 await asyncio.sleep(self._delay)
 
     async def async_learn_command(self, **kwargs):
-        command = kwargs.get("command")
-        command_data = kwargs.get("command_data", [])
-        if command:
-            self._commands[command] = command_data
+        command = kwargs.get("command") or kwargs.get("key")
+        _LOGGER.debug("Learn command requested: %s", command)
+        if not command:
+            _LOGGER.error("No command name provided for learn_command")
+            return
+
+        try:
+            learned = await self._controller.learn()
+        except NotImplementedError:
+            _LOGGER.error("Controller does not support learning")
+            return
+        except Exception as err:  # pragma: no cover - depends on HA
+            _LOGGER.error("Error while learning command %s: %s", command, err)
+            return
+
+        if learned:
+            self._commands[command] = [learned]
+            _LOGGER.debug("Learned command %s: %s", command, learned)
+        else:
+            _LOGGER.warning("No IR code learned for %s", command)
 
     async def async_delete_command(self, **kwargs):
         command = kwargs.get("command")


### PR DESCRIPTION
## Summary
- add generic `learn` hook for controllers
- implement ZHA IR code learning with retries and debug logging
- log and store learned commands via remote entity

## Testing
- `pytest tests/test_remote.py -q`

------
https://chatgpt.com/codex/tasks/task_b_689209ca57b88326b256c0848e374202